### PR TITLE
Keep control state after erroneous form validation

### DIFF
--- a/wicket-select2/src/main/java/com/vaynberg/wicket/select2/Select2Choice.java
+++ b/wicket-select2/src/main/java/com/vaynberg/wicket/select2/Select2Choice.java
@@ -56,13 +56,19 @@ public class Select2Choice<T> extends AbstractSelect2Choice<T, T> {
 
     @Override
     protected void renderInitializationScript(IHeaderResponse response) {
-	if (getModelObject() != null) {
+    	
+    	T state = getConvertedInput();
+    	if (state == null) {
+    	    state = getModelObject();
+    	}
+    	
+	if (state != null) {
 
 	    JsonBuilder selection = new JsonBuilder();
 
 	    try {
 		selection.object();
-		getProvider().toJson(getModelObject(), selection);
+		getProvider().toJson(state, selection);
 		selection.endObject();
 	    } catch (JSONException e) {
 		throw new RuntimeException("Error converting model object to Json", e);


### PR DESCRIPTION
After unsuccesful form validation, the control's value is kept properly in the value attribute. however, the control may not be properly initialized due to using only getModelObject other than the control's current state.
