### PR TITLE
It is impossible to set either dropdownCss or containerCss via Settings

### DIFF
--- a/wicket-select2/src/main/java/com/vaynberg/wicket/select2/Settings.java
+++ b/wicket-select2/src/main/java/com/vaynberg/wicket/select2/Settings.java
@@ -89,9 +89,9 @@ public final class Settings implements Serializable {
 	    Json.writeFunction(writer, "query", query);
 	    Json.writeObject(writer, "width", width);
 	    Json.writeObject(writer, "openOnEnter", openOnEnter);
-	    Json.writeObject(writer, "containerCss", containerCss);
+	    Json.writeFunction(writer, "containerCss", containerCss);
 	    Json.writeObject(writer, "containerCssClass", containerCssClass);
-	    Json.writeObject(writer, "dropdownCss", dropdownCss);
+	    Json.writeFunction(writer, "dropdownCss", dropdownCss);
 	    Json.writeObject(writer, "dropdownCssClass", dropdownCssClass);
 	    Json.writeObject(writer, "separator", separator);
 	    Json.writeObject(writer, "tokenSeparators", tokenSeparators);


### PR DESCRIPTION
Both of these properties are described as "either an object containing css property/value key pairs or a function that returns such an object" but nevertheless both are rendered in javascript as escaped javascript strings, because .writeObject is used instead of .writeFunction in Settings.toJson()
