### PR TITLE
Add support for JSON IDs

### DIFF
--- a/wicket-select2/src/main/java/com/vaynberg/wicket/select2/Select2MultiChoice.java
+++ b/wicket-select2/src/main/java/com/vaynberg/wicket/select2/Select2MultiChoice.java
@@ -12,17 +12,17 @@
  */
 package com.vaynberg.wicket.select2;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-
+import com.vaynberg.wicket.select2.json.JsonBuilder;
 import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.head.OnDomReadyHeaderItem;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.util.string.Strings;
 import org.json.JSONException;
 
-import com.vaynberg.wicket.select2.json.JsonBuilder;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * Multi-select Select2 component. Should be attached to a {@code <input type='hidden'/>} element.
@@ -34,7 +34,7 @@ import com.vaynberg.wicket.select2.json.JsonBuilder;
  */
 public class Select2MultiChoice<T> extends AbstractSelect2Choice<T, Collection<T>> {
 
-    public Select2MultiChoice(String id, IModel<Collection<T>> model, ChoiceProvider<T> provider) {
+	public Select2MultiChoice(String id, IModel<Collection<T>> model, ChoiceProvider<T> provider) {
 	super(id, model, provider);
     }
 
@@ -55,13 +55,46 @@ public class Select2MultiChoice<T> extends AbstractSelect2Choice<T, Collection<T
 	if (Strings.isEmpty(input)) {
 	    choices = new ArrayList<T>();
 	} else {
-	    choices = getProvider().toChoices(Arrays.asList(input.split(",")));
+		List<String> ids = splitInput( input );
+		choices = getProvider().toChoices( ids );
 	}
 
 	setConvertedInput(choices);
     }
 
-    @Override
+	static List<String> splitInput( String input ) {
+
+		if( input.startsWith( "{" ) && input.endsWith( "}" )) {
+			// Assume we're using JSON IDs
+			List<String> result = new ArrayList<String>();
+
+			int openBracket = 0;
+			Integer lastStartIdx = null;
+			for( int i = 0; i < input.length(); i++ ) {
+				char c = input.charAt( i );
+				if( c == '{' ) {
+					openBracket++;
+					if( lastStartIdx == null) {
+						lastStartIdx = i;
+					}
+				}
+				if( c == '}' ) {
+					openBracket--;
+					if( openBracket == 0 ) {
+						String substring = input.substring( lastStartIdx, i + 1 );
+						result.add( substring );
+						lastStartIdx = null;
+					}
+				}
+			}
+
+			return result;
+		}
+
+		return Arrays.asList( input.split( "," ) );
+	}
+
+	@Override
     public void updateModel() {
 	Collection<T> choices = getModelObject();
 	Collection<T> selection = getConvertedInput();

--- a/wicket-select2/src/test/java/com/vaynberg/wicket/select2/Select2MultiChoiceTest.java
+++ b/wicket-select2/src/test/java/com/vaynberg/wicket/select2/Select2MultiChoiceTest.java
@@ -1,0 +1,64 @@
+package com.vaynberg.wicket.select2;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * User: npratt
+ * Date: 4/3/14
+ * Time: 10:21
+ */
+public class Select2MultiChoiceTest
+{
+	@Test
+	public void testSplitWithSingleValue() throws Exception
+	{
+		List<String> strings = Select2MultiChoice.splitInput( "A" );
+		assertEquals( 1, strings.size() );
+		assertEquals( "A", strings.get( 0 ) );
+	}
+
+	@Test
+	public void testSplitWithRegularCSV() throws Exception
+	{
+		List<String> strings = Select2MultiChoice.splitInput( "A,B,C" );
+		assertEquals( 3, strings.size() );
+	}
+
+	@Test
+	public void testSplitWithSingleJsonId() throws Exception
+	{
+		String jsonId = "{\"someKey\":\"someValue\"}";
+		List<String> strings = Select2MultiChoice.splitInput( jsonId );
+		assertEquals( 1, strings.size() );
+		assertEquals( jsonId, strings.get( 0 ) );
+	}
+
+	@Test
+	public void testSplitWithSingleJsonIdThatHasNestedObjects() throws Exception
+	{
+		String jsonId = "{\"email\":{\"emailAddress\":\"test@test.com\"},\"isContact\":true}";
+		List<String> strings = Select2MultiChoice.splitInput( jsonId );
+		assertEquals( 1, strings.size() );
+		assertEquals( jsonId, strings.get( 0 ) );
+	}
+
+	@Test
+	public void testSplitWithMultipleJsonIds() throws Exception
+	{
+		String jsonId = "{\"someKey\":\"someValue\"},{\"someKey\":\"otherValue\"}";
+		List<String> strings = Select2MultiChoice.splitInput( jsonId );
+		assertEquals( 2, strings.size() );
+	}
+
+	@Test
+	public void testSplitWithMultipleJsonIdsAndNestedJsonObjects() throws Exception
+	{
+		List<String> strings = Select2MultiChoice.splitInput(
+				"{\"email\":{\"emailAddress\":\"nouser@test.com\"},\"isContact\":true},{\"email\":{\"emailAddress\":\"otheruser@test.com\"},\"isContact\":contact}" );
+		assertEquals( 2, strings.size() );
+	}
+}


### PR DESCRIPTION
Select2MultiChoice made the assumption that the provided IDs did not contain any commas.  Now the split routine checks to see if the provided IDs are enclosed in curly brackets and then attempts to parse out the comma separated JSON objects accordingly.
