### PR TITLE
Do not overwrite the updateModel method of a FormComponent

### DIFF
--- a/wicket-select2/src/main/java/com/vaynberg/wicket/select2/Select2MultiChoice.java
+++ b/wicket-select2/src/main/java/com/vaynberg/wicket/select2/Select2MultiChoice.java
@@ -62,20 +62,6 @@ public class Select2MultiChoice<T> extends AbstractSelect2Choice<T, Collection<T
     }
 
     @Override
-    public void updateModel() {
-	Collection<T> choices = getModelObject();
-	Collection<T> selection = getConvertedInput();
-
-	if (choices == null) {
-	    getModel().setObject(selection);
-	} else {
-	    choices.clear();
-	    choices.addAll(selection);
-	    getModel().setObject(choices);
-	}
-    }
-
-    @Override
     protected void onInitialize() {
 	super.onInitialize();
 	getSettings().setMultiple(true);


### PR DESCRIPTION
- if you use wicket the right way there is no need the overwrite the updateModel method for a custom form component
- this strange code inside the updateModel method caused an error in combination with the wicket-bootstrap library
  -> the FormGroup component implements the interface IFormModelUpdateListener (which is also wrong) and cause that the updateModel method of each FormComponent gets called twice
  -> calling this updateModel method twice within one request cycle results in an empty collection for the model object
